### PR TITLE
Add optional filters for score/cvgpct, pctid

### DIFF
--- a/SerratusApi/Utills/Utills.cs
+++ b/SerratusApi/Utills/Utills.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Linq;
+
+namespace SerratusApi.Utills
+{
+    public static class Utills
+    {
+        public static (int low, int high) parseQueryParameterRange(string range)
+        {
+            if (string.IsNullOrEmpty(range))
+            {
+                throw new ArgumentException();
+            }
+            var subrange = range.Substring(1, range.Length - 2);
+            var numbers = subrange.Split("-").ToList();
+
+            if (numbers.Count != 2)
+            {
+                throw new ArgumentException();
+            }
+
+            var low = Int16.Parse(numbers[0]);
+            var high = Int16.Parse(numbers[1]);
+
+            return (low, high);
+
+        }
+    }
+}


### PR DESCRIPTION
Backwards-compatible change.

Example current routes (links for `localhost:36309`):

- [`/api/family/get-runs/Coronaviridae?page=1&itemsPerPage=20`](http://localhost:36309/api/family/get-runs/Coronaviridae?page=1&itemsPerPage=20)
- [`/api/genbank/get-runs/EU769558.1?page=1&itemsPerPage=20`](http://localhost:36309/api/genbank/get-runs/EU769558.1?page=1&itemsPerPage=20)

Example new routes:

- [`/api/family/get-runs/Coronaviridae?page=1&itemsPerPage=20&pctId=[80-90]`](http://localhost:36309/api/family/get-runs/Coronaviridae?page=1&itemsPerPage=20&pctId=[80-90])
- [`/api/family/get-runs/Coronaviridae?page=1&itemsPerPage=20&score=[60-100]`](http://localhost:36309/api/family/get-runs/Coronaviridae?page=1&itemsPerPage=20&score=[60-100])
- [`/api/family/get-runs/Coronaviridae?page=1&itemsPerPage=20&pctId=[80-90]&score=[60-100]`](http://localhost:36309/api/family/get-runs/Coronaviridae?page=1&itemsPerPage=20&pctId=[80-90]&score=[60-100])
- [`/api/genbank/get-runs/EU769558.1?page=1&itemsPerPage=20&pctId=[85-90]`](http://localhost:36309/api/genbank/get-runs/EU769558.1?page=1&itemsPerPage=20&pctId=[85-90])
- [`/api/genbank/get-runs/EU769558.1?page=1&itemsPerPage=20&cvgPct=[10-30]`](http://localhost:36309/api/genbank/get-runs/EU769558.1?page=1&itemsPerPage=20&cvgPct=[10-30])
- [`/api/genbank/get-runs/EU769558.1?page=1&itemsPerPage=20&pctId=[85-90]&cvgPct=[10-30]`](http://localhost:36309/api/genbank/get-runs/EU769558.1?page=1&itemsPerPage=20&pctId=[85-90]&cvgPct=[10-30])

closes #5.